### PR TITLE
Block a few tests from running on forks

### DIFF
--- a/.github/workflows/example-hugo-cleanup-cloudflare.yaml
+++ b/.github/workflows/example-hugo-cleanup-cloudflare.yaml
@@ -29,6 +29,7 @@ jobs:
 
   cleanup-staging:
     needs: get-branch-name
+    if: ${{ github.repository == vars.MAIN_REPO }}
     uses: omsf/static-site-tools/.github/workflows/cleanup-cloudflare.yaml@main
     with:
       pr_number: ${{ fromJSON(needs.get-branch-name.outputs.pr_number) }}

--- a/.github/workflows/test-hugo-cleanup.yaml
+++ b/.github/workflows/test-hugo-cleanup.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   check_pr1_deployment_count:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == vars.MAIN_REPO }}
     steps:
       # TODO: maybe make extract the right PR and check against any PR?
       # Always checking against pr-1 should also be true, since it is


### PR DESCRIPTION
My fork was giving errors because a few workflows were running that can't run on forks. This should clean that up.

Will merge with only copilot review because:

1. Ethan is on holiday
2. I'm pretty sure these 2 changes won't break anything.