### PR TITLE
Try getting the alias URL instead of the deployment

### DIFF
--- a/.github/workflows/stage-cloudflare.yaml
+++ b/.github/workflows/stage-cloudflare.yaml
@@ -113,6 +113,6 @@ jobs:
           header: ${{ inputs.label }}
           number: ${{ inputs.pr-number }}
           message: |
-            This PR has been staged at ${{ needs.stage-from-artifact.outputs.deployment_url }}.
+            This PR has been staged at ${{ needs.stage-from-artifact.outputs.pages-deployment-alias-url }}.
 
             It has been updated for commit ${{ inputs.pr-headsha }}.


### PR DESCRIPTION
Of course, I can't test this in a PR. So I'll merge it and see if it works the next time I open a PR.