### PR TITLE
Revert "Try getting the alias URL instead of the deployment"

### DIFF
--- a/.github/workflows/stage-cloudflare.yaml
+++ b/.github/workflows/stage-cloudflare.yaml
@@ -113,6 +113,6 @@ jobs:
           header: ${{ inputs.label }}
           number: ${{ inputs.pr-number }}
           message: |
-            This PR has been staged at ${{ needs.stage-from-artifact.outputs.pages-deployment-alias-url }}.
+            This PR has been staged at ${{ needs.stage-from-artifact.outputs.deployment_url }}.
 
             It has been updated for commit ${{ inputs.pr-headsha }}.


### PR DESCRIPTION
Reverts omsf/static-site-tools#10

This broke entirely. Maybe check specific version of the action?