### PR TITLE
feat: Add Astro support

### DIFF
--- a/build/astro/action.yml
+++ b/build/astro/action.yml
@@ -1,0 +1,18 @@
+name: Build Astro Site
+description: Build a site with Astro using Bun
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Dependencies with Bun
+      uses: oven-sh/setup-bun@v2
+      shell: bash
+      run: bun install --frozen-lockfile
+
+    - name: Build Astro site
+      shell: bash
+      run: bun run build
+
+
+
+


### PR DESCRIPTION
This PR aims to add support for building and deploying [Astro](https://astro.build/) sites to Cloudflare Pages. It is important to note that this support may not working the future if we add server functions in the future, but for now this should be a start for our use case.