### PR TITLE
Add dummy job to test-hugo-cleanup

### DIFF
--- a/.github/workflows/test-hugo-cleanup.yaml
+++ b/.github/workflows/test-hugo-cleanup.yaml
@@ -6,6 +6,13 @@ on:
     types: [completed]
 
 jobs:
+  no-op:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository != vars.MAIN_REPO }}
+    steps:
+      - name: Skip on forks
+        run: echo "Skipping test on fork repository"
+
   check_pr1_deployment_count:
     runs-on: ubuntu-latest
     if: ${{ github.repository == vars.MAIN_REPO }}


### PR DESCRIPTION
If you have a fork of the main repo, tests for the "Cleanup" process always skip. When a scheduled run skips all jobs, GitHub apparently thinks this is a problem you need to be notified about. As a result, I've been getting daily emails like this:

<img width="532" alt="image" src="https://github.com/user-attachments/assets/fdf852ed-3189-4450-8c65-68676d4286e7" />

I'm hoping that adding this dummy job that runs on forks will mean I stop getting this email notification every day.