### PR TITLE
Terraform modules for simple setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,46 @@ deployments from the branch when the PR is closed.
 
 ## Preparing to Install
 
+### Automatically Using OpenTofu/Terraform
+---
+We are able to setup the required Cloudflare Pages project and required GitHub Secrets and Variables using OpenTofu/Terraform.
+
+To do so, you would create an OpenTofu project and use the two modules in the module folder which would look like this:
+
+```hcl
+locals {
+    cloudflare_account_id = "your-cloudflare-account-id"
+    cloudflare_project_name = "your-pages-project-name"
+}
+
+module "cloudflare_pages" {
+  source = "github.com/omsf/static-site-tools//modules/cloudflare_pages"
+
+  cloudflare_token_name   = "my-pages-token"
+  cloudflare_project_name = local.cloudflare_project_name
+  cloudflare_account_id   = local.cloudflare_account_id
+  
+  # Optional: specify a custom compatibility date
+  cf_compat_date = "2024-01-01"
+}
+
+module "github_vars" {
+  source = "github.com/omsf/static-site-tools//modules/github_vars"
+
+  github_repository         = "owner/repository-name"
+  cloudflare_account_id     = local.cloudflare_account_id
+  cloudflare_token          = "$(module.cloudflare_pages.cloudflare_token)"
+  cloudflare_project_name   = local.cloudflare_project_name
+  
+  # Optional: customize variable names
+  cloudflare_account_id_var_name   = "CLOUDFLARE_ACCOUNT_ID"
+  cloudflare_token_var_name        = "CLOUDFLARE_API_TOKEN"
+  cloudflare_project_name_var_name = "CLOUDFLARE_PROJECT_NAME"
+}
+```
+
+### Manually
+---
 ### Cloudflare
 
 Please note that we have a [separate page](cloudflare-setup.md) documenting how

--- a/modules/cloudflare_pages/README.md
+++ b/modules/cloudflare_pages/README.md
@@ -1,0 +1,56 @@
+# Cloudflare Pages Module
+
+This Terraform module creates a Cloudflare Pages project and generates an API token with the necessary permissions to manage the project.
+
+## Features
+
+- Creates a Cloudflare Pages project with configurable name and production branch
+- Generates a dedicated API token with minimal required permissions for Pages management
+- Supports custom compatibility dates or uses the first apply date as default
+- Configures both preview and production deployment environments
+
+## Usage
+
+```hcl
+module "cloudflare_pages" {
+  source = "./modules/cloudflare_pages"
+
+  cloudflare_token_name   = "my-pages-token"
+  cloudflare_project_name = "my-awesome-site"
+  cloudflare_account_id   = "your-cloudflare-account-id"
+  
+  # Optional: specify a custom compatibility date
+  cf_compat_date = "2024-01-01"
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| cloudflare_token_name | Name of the Cloudflare API token | `string` | n/a | yes |
+| cloudflare_project_name | Name of the Cloudflare Pages project | `string` | n/a | yes |
+| cloudflare_account_id | Cloudflare account ID | `string` | n/a | yes |
+| cf_compat_date | Optional override for Cloudflare compatibility date (YYYY-MM-DD). Leave empty to use first-apply date. | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| cloudflare_token | The Cloudflare API token ID with read/write access to your Cloudflare pages (sensitive) |
+| cloudflare_subdomain | The subdomain of the Cloudflare Pages project |
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0 |
+| cloudflare | ~> 4.0 |
+| time | ~> 0.13 |
+
+## Notes
+
+- The generated API token has minimal permissions (Pages Write only) for security
+- The compatibility date is automatically set to prevent unwanted in-place updates
+- The module uses a time resource to capture the first apply date if no custom date is provided
+- The API token is marked as sensitive and will not be displayed in Terraform output

--- a/modules/cloudflare_pages/README.md
+++ b/modules/cloudflare_pages/README.md
@@ -15,7 +15,7 @@ Note: to deploy this module, you'll need a local API token with permissions to c
 
 ```hcl
 module "cloudflare_pages" {
-  source = "./modules/cloudflare_pages"
+  source = "github.com/omsf/static-site-tools//modules/cloudflare_pages"
 
   cloudflare_token_name   = "my-pages-token"
   cloudflare_project_name = "my-awesome-site"

--- a/modules/cloudflare_pages/README.md
+++ b/modules/cloudflare_pages/README.md
@@ -2,6 +2,8 @@
 
 This Terraform module creates a Cloudflare Pages project and generates an API token with the necessary permissions to manage the project.
 
+Note: to deploy this module, you'll need a local API token with permissions to create tokens and to write/edit Cloudflare Pages projects. The easiest way to generate this is to start making a new account token with the "Create Additional Tokens" permission, and then to add Cloudflare Pages Edit permission.
+
 ## Features
 
 - Creates a Cloudflare Pages project with configurable name and production branch

--- a/modules/cloudflare_pages/main.tf
+++ b/modules/cloudflare_pages/main.tf
@@ -1,0 +1,56 @@
+
+data "cloudflare_account_api_token_permission_groups_list" "groups" {
+  account_id = var.cloudflare_account_id
+  name       = "Pages%20Write"
+}
+
+locals {
+  pages_edit = sensitive(data.cloudflare_account_api_token_permission_groups_list.groups.result[0].id)
+}
+
+# Cloudflare API token
+# This is the API token that will have read/write access to your Cloudflare
+# pages. It is used within the GitHub Actions. Note that this is different
+# from the API token you need to deploy this Terraform configuration.
+resource "cloudflare_account_token" "this" {
+  name       = var.cloudflare_token_name
+  account_id = var.cloudflare_account_id
+  policies = [{
+    effect = "allow"
+    permission_groups = [{
+      id = local.pages_edit
+    }]
+    resources = {
+      "com.cloudflare.api.account.${var.cloudflare_account_id}" = "*"
+    }
+  }]
+}
+
+# Setting the compatibility date; without this the pages resource will
+# try to edit in place every on every apply. We set it to the first time
+# Terraform applies this configuration, unless the user provides a value.
+resource "time_static" "cf_compat" {}
+
+locals {
+  first_apply_date = formatdate("YYYY-MM-DD", time_static.cf_compat.rfc3339)
+  compat_date      = var.cf_compat_date != "" ? var.cf_compat_date : local.first_apply_date
+}
+
+# Cloudflare pages project
+resource "cloudflare_pages_project" "this" {
+  account_id        = var.cloudflare_account_id
+  name              = var.cloudflare_project_name
+  production_branch = "main"
+  build_config      = {}
+  deployment_configs = {
+    preview = {
+      compatibility_date  = local.compat_date
+      compatibility_flags = []
+    }
+    production = {
+      compatibility_date  = local.compat_date
+      compatibility_flags = []
+    }
+  }
+
+}

--- a/modules/cloudflare_pages/outputs.tf
+++ b/modules/cloudflare_pages/outputs.tf
@@ -1,0 +1,10 @@
+output "cloudflare_token" {
+  value       = cloudflare_account_token.this.value
+  description = "The Cloudflare API token ID with read/write access to your Cloudflare pages."
+  sensitive   = true
+}
+
+output "cloudflare_subdomain" {
+  value       = cloudflare_pages_project.this.subdomain
+  description = "The subdomain of the Cloudflare Pages project."
+}

--- a/modules/cloudflare_pages/terraform.tf
+++ b/modules/cloudflare_pages/terraform.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13"
+    }
+  }
+}

--- a/modules/cloudflare_pages/terraform.tf
+++ b/modules/cloudflare_pages/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     time = {
       source  = "hashicorp/time"

--- a/modules/cloudflare_pages/variables.tf
+++ b/modules/cloudflare_pages/variables.tf
@@ -1,0 +1,26 @@
+variable "cloudflare_token_name" {
+  description = "Name of the Cloudflare API token"
+  type        = string
+}
+
+variable "cloudflare_project_name" {
+  description = "Name of the Cloudflare Pages project"
+  type        = string
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "cf_compat_date" {
+  description = "Optional override for Cloudflare compatibility date (YYYY-MM-DD). Leave empty to use first-apply date."
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.cf_compat_date == "" || can(regex("^\\d{4}-\\d{2}-\\d{2}$", var.cf_compat_date))
+    error_message = "cf_compat_date must be empty or in YYYY-MM-DD format."
+  }
+}
+

--- a/modules/github_vars/README.md
+++ b/modules/github_vars/README.md
@@ -1,0 +1,69 @@
+# GitHub Variables Module
+
+This Terraform module manages GitHub Actions secrets and variables for Cloudflare Pages integration. It sets up the necessary credentials and configuration variables in a GitHub repository to enable automated deployments to Cloudflare Pages.
+
+## Features
+
+- Creates GitHub Actions secrets for sensitive Cloudflare credentials
+- Sets up GitHub Actions variables for non-sensitive configuration
+- Configurable variable names for flexibility
+- Automatic repository validation
+
+## Usage
+
+```hcl
+module "github_vars" {
+  source = "./modules/github_vars"
+
+  github_repository         = "owner/repository-name"
+  cloudflare_account_id     = "your-cloudflare-account-id"
+  cloudflare_token          = "your-cloudflare-api-token"
+  cloudflare_project_name   = "your-pages-project-name"
+  
+  # Optional: customize variable names
+  cloudflare_account_id_var_name   = "CLOUDFLARE_ACCOUNT_ID"
+  cloudflare_token_var_name        = "CLOUDFLARE_API_TOKEN"
+  cloudflare_project_name_var_name = "CLOUDFLARE_PROJECT_NAME"
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| github_repository | GitHub repository name in the format 'owner/repo' | `string` | n/a | yes |
+| cloudflare_account_id | Cloudflare account ID | `string` | n/a | yes |
+| cloudflare_token | Cloudflare API token with permissions for pages | `string` | n/a | yes |
+| cloudflare_project_name | Name of the Cloudflare Pages project | `string` | n/a | yes |
+| cloudflare_account_id_var_name | Name of the variable for Cloudflare account ID | `string` | `"CLOUDFLARE_ACCOUNT_ID"` | no |
+| cloudflare_token_var_name | Name of the variable for Cloudflare API token | `string` | `"CLOUDFLARE_API_TOKEN"` | no |
+| cloudflare_project_name_var_name | Name of the variable for Cloudflare project name | `string` | `"CLOUDFLARE_PROJECT_NAME"` | no |
+
+## Outputs
+
+No outputs. Secrets are not preserved in the state file for security reasons.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.0 |
+| github | ~> 5.0 |
+| cloudflare | ~> 4.0 |
+
+## Resources Created
+
+### Secrets (Sensitive)
+- `CLOUDFLARE_ACCOUNT_ID` - Cloudflare account ID
+- `CLOUDFLARE_API_TOKEN` - Cloudflare API token with Pages permissions
+
+### Variables (Non-sensitive)
+- `CLOUDFLARE_PROJECT_NAME` - Name of the Cloudflare Pages project
+- `MAIN_REPO` - GitHub repository name for reference
+
+## Notes
+
+- Secrets are encrypted and not visible in the GitHub UI after creation
+- Variables are visible in the GitHub UI and should not contain sensitive data
+- The module validates the repository exists before creating secrets/variables
+- Variable names can be customized to match your workflow requirements

--- a/modules/github_vars/README.md
+++ b/modules/github_vars/README.md
@@ -13,7 +13,7 @@ This Terraform module manages GitHub Actions secrets and variables for Cloudflar
 
 ```hcl
 module "github_vars" {
-  source = "./modules/github_vars"
+  source = "github.com/omsf/static-site-tools//modules/github_vars"
 
   github_repository         = "owner/repository-name"
   cloudflare_account_id     = "your-cloudflare-account-id"

--- a/modules/github_vars/main.tf
+++ b/modules/github_vars/main.tf
@@ -1,0 +1,29 @@
+data "github_repository" "repo" {
+  full_name = var.github_repository
+}
+
+# GitHub Actions secrets
+resource "github_actions_secret" "cloudflare_account_id" {
+  repository      = data.github_repository.repo.name
+  secret_name     = var.cloudflare_account_id_var_name
+  plaintext_value = var.cloudflare_account_id
+}
+
+resource "github_actions_secret" "cloudflare_token" {
+  repository      = data.github_repository.repo.name
+  secret_name     = var.cloudflare_token_var_name
+  plaintext_value = var.cloudflare_token
+}
+
+# GitHub Actions Variables
+resource "github_actions_variable" "cloudflare_project_name" {
+  repository    = data.github_repository.repo.name
+  variable_name = var.cloudflare_project_name_var_name
+  value         = var.cloudflare_project_name
+}
+
+resource "github_actions_variable" "main_repo" {
+  repository    = data.github_repository.repo.name
+  variable_name = "MAIN_REPO"
+  value         = var.github_repository
+}

--- a/modules/github_vars/terraform.tf
+++ b/modules/github_vars/terraform.tf
@@ -6,7 +6,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 

--- a/modules/github_vars/terraform.tf
+++ b/modules/github_vars/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = ">= 1.0"
+}

--- a/modules/github_vars/variables.tf
+++ b/modules/github_vars/variables.tf
@@ -1,0 +1,37 @@
+variable "github_repository" {
+  description = "GitHub repository name in the format 'owner/repo'"
+  type        = string
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_token" {
+  description = "Cloudflare API token with permissions for pages"
+  type        = string
+}
+
+variable "cloudflare_project_name" {
+  description = "Name of the Cloudflare Pages project"
+  type        = string
+}
+
+variable "cloudflare_account_id_var_name" {
+  description = "Name of the variable for Cloudflare account ID"
+  type        = string
+  default     = "CLOUDFLARE_ACCOUNT_ID"
+}
+
+variable "cloudflare_token_var_name" {
+  description = "Name of the variable for Cloudflare API token"
+  type        = string
+  default     = "CLOUDFLARE_API_TOKEN"
+}
+
+variable "cloudflare_project_name_var_name" {
+  description = "Name of the variable for Cloudflare project name"
+  type        = string
+  default     = "CLOUDFLARE_PROJECT_NAME"
+}


### PR DESCRIPTION
This PR adds Terraform modules for managing static site infrastructure. They're split out between Cloudflare and GitHub. The Cloudflare module handles creating a Cloudflare Pages project and an API token with Cloudflare Pages Write access. The GitHub module handles creating all the secrets and variables that are needed for our static sites. I don't do anything with Cloudflare DNS here because I'm not using it on anything.

I built this out locally on a personal project, you can see usage here: https://github.com/dwhswenson/ultrasound/blob/main/main.tf. I've copied over the modules from there, and intend to rebuild the infra for that site once I can point to online modules in this repo.