### PR TITLE
feat: add suport for a non-standard site installs

### DIFF
--- a/.github/workflows/example-generic-build-pr.yaml
+++ b/.github/workflows/example-generic-build-pr.yaml
@@ -1,0 +1,42 @@
+name: Package generic static site from PR
+
+on:
+  pull_request:
+    branches:
+      - main
+  # SCHEDULE AND WORKFLOW DISPATCH USED FOR TESTING
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+env:
+  GENERIC_SOURCE_DIR: "example-generic"
+  GENERIC_BASE_URL: ""
+  GENERIC_OUTPUT_DIR: "."
+  # if you change GENERIC_OUTPUT_DIR, also add a repository variable for it
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Test site
+        uses: omsf/static-site-tools/common-tests@main
+        with:
+          site-directory: ${{ env.GENERIC_SOURCE_DIR }}/${{ env.GENERIC_OUTPUT_DIR}}
+          base-url: ${{ env.GENERIC_BASE_URL }}
+
+      - name: Make artifact
+        shell: bash
+        run: tar czf "$RUNNER_TEMP/site.tar.gz" -C ${{ env.GENERIC_SOURCE_DIR }} ${{ env.GENERIC_OUTPUT_DIR }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-build
+          path: ${{ runner.temp }}/site.tar.gz
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/example-generic-build-pr.yaml
+++ b/.github/workflows/example-generic-build-pr.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Make artifact
         shell: bash
-        run: tar czf "$RUNNER_TEMP/site.tar.gz" -C ${{ env.GENERIC_SOURCE_DIR }} ${{ env.GENERIC_OUTPUT_DIR }}
+        run: tar --exclude-vcs -czf "$RUNNER_TEMP/site.tar.gz" -C ${{ env.GENERIC_SOURCE_DIR }} ${{ env.GENERIC_OUTPUT_DIR }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/example-generic-build-push.yaml
+++ b/.github/workflows/example-generic-build-push.yaml
@@ -1,0 +1,34 @@
+name: Package generic static site from push
+
+on:
+  push:
+    branches:
+      - main
+  # SCHEDULE AND WORKFLOW DISPATCH ARE FOR TESTING
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+env:
+  GENERIC_SOURCE_DIR: "example-generic"
+  GENERIC_OUTPUT_DIR: "."
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Make artifact
+        shell: bash
+        run: tar czf "$RUNNER_TEMP/site.tar.gz" -C ${{ env.GENERIC_SOURCE_DIR }} ${{ env.GENERIC_OUTPUT_DIR }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-build
+          path: ${{ runner.temp }}/site.tar.gz
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/example-generic-build-push.yaml
+++ b/.github/workflows/example-generic-build-push.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Make artifact
         shell: bash
-        run: tar czf "$RUNNER_TEMP/site.tar.gz" -C ${{ env.GENERIC_SOURCE_DIR }} ${{ env.GENERIC_OUTPUT_DIR }}
+        run: tar --exclude-vcs -czf "$RUNNER_TEMP/site.tar.gz" -C ${{ env.GENERIC_SOURCE_DIR }} ${{ env.GENERIC_OUTPUT_DIR }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/example-generic-cleanup-cloudflare.yaml
+++ b/.github/workflows/example-generic-cleanup-cloudflare.yaml
@@ -1,0 +1,39 @@
+name: Cleanup generic static site staging
+description: Cleanup staging environment; this occurs on PR merge or close
+
+on:
+  pull_request_target:
+    types: [closed]
+  # TESTING
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  get-branch-name:
+    if: ${{ github.repository == vars.MAIN_REPO }}
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.get_pr_number.outputs.pr_num }}
+    steps:
+      - name: Get PR number
+        id: get_pr_number
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            pr_num=${{ github.event.pull_request.number }}
+          else
+            # for testing
+            pr_num=-1
+          fi
+          echo "pr_num=${pr_num}" | tee -a "$GITHUB_OUTPUT"
+
+  cleanup-staging:
+    needs: get-branch-name
+    if: ${{ github.repository == vars.MAIN_REPO }}
+    uses: omsf/static-site-tools/.github/workflows/cleanup-cloudflare.yaml@main
+    with:
+      pr_number: ${{ fromJSON(needs.get-branch-name.outputs.pr_number) }}
+      project_name: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/example-generic-prod-cloudflare.yaml
+++ b/.github/workflows/example-generic-prod-cloudflare.yaml
@@ -1,0 +1,21 @@
+name: Deploy generic static site to production
+
+on:
+  workflow_run:
+    workflows: ["Package generic static site from push"]
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  deploy-to-prod:
+    if: ${{ (github.event.workflow_run.conclusion == 'success') && (github.repository == vars.MAIN_REPO) }}
+    uses: omsf/static-site-tools/.github/workflows/prod-cloudflare.yaml@main
+    with:
+      run-id: ${{ github.event.workflow_run.id }}
+      project-name: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
+      html-dir: ${{ vars.GENERIC_OUTPUT_DIR || '.' }}
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/example-generic-stage-cloudflare.yaml
+++ b/.github/workflows/example-generic-stage-cloudflare.yaml
@@ -1,0 +1,48 @@
+name: Upload generic static site to staging
+
+on:
+  workflow_run:
+    workflows: ["Package generic static site from PR"]
+    types:
+      - completed
+
+jobs:
+  get-metadata:
+    if: ${{ github.repository == vars.MAIN_REPO }}
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.pr-metadata.outputs.pr-number || steps.backup-metadata.outputs.pr-number }}
+      pr_headsha: ${{ steps.pr-metadata.outputs.pr-headsha || steps.backup-metadata.outputs.pr-headsha }}
+
+    steps:
+      - name: Get PR metadata from action
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
+        id: pr-metadata
+        uses: omsf/static-site-tools/pr-info-from-workflow-run@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Backup metadata for testing
+        id: backup-metadata
+        if: ${{ github.repository == vars.MAIN_REPO && contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event.workflow_run.event) }}
+        shell: bash
+        run: |
+          echo "pr-headsha=test" | tee -a "$GITHUB_OUTPUT"
+          echo "pr-number=-1" | tee -a "$GITHUB_OUTPUT"
+
+  stage:
+    if: ${{ (github.event.workflow_run.conclusion == 'success') && (github.repository == vars.MAIN_REPO) }}
+    needs: get-metadata
+    uses: omsf/static-site-tools/.github/workflows/stage-cloudflare.yaml@main
+    permissions:
+      statuses: write
+      pull-requests: write
+    with:
+      run-id: ${{ github.event.workflow_run.id }}
+      pr-number: ${{ fromJSON(needs.get-metadata.outputs.pr_number) }}
+      pr-headsha: ${{ needs.get-metadata.outputs.pr_headsha }}
+      project-name: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
+      html-dir: ${{ vars.GENERIC_OUTPUT_DIR || '.' }}
+      label: Generic static site
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/example-generic/README.md
+++ b/example-generic/README.md
@@ -1,0 +1,13 @@
+# Generic Static Site Example
+
+This is a plain static site example for the `generic` installer option.
+
+It does not require Astro, Hugo, Jekyll, or another static site generator. The
+installed generic workflows package this directory as-is and deploy the files to
+Cloudflare Pages.
+
+Install workflows for this example with:
+
+```bash
+python3 install.py generic --site-dir example-generic
+```

--- a/example-generic/assets/styles.css
+++ b/example-generic/assets/styles.css
@@ -1,0 +1,65 @@
+:root {
+  color-scheme: light dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #f7f7f3;
+  color: #20201d;
+}
+
+.page {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 2rem;
+}
+
+.card {
+  max-width: 42rem;
+  border: 1px solid #d8d7cc;
+  border-radius: 1rem;
+  background: #ffffff;
+  padding: 2rem;
+  box-shadow: 0 1rem 3rem rgb(32 32 29 / 10%);
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #66645c;
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1;
+}
+
+p {
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #171714;
+    color: #f5f2e8;
+  }
+
+  .card {
+    border-color: #3d3b34;
+    background: #20201d;
+  }
+
+  .eyebrow {
+    color: #b9b5a8;
+  }
+}

--- a/example-generic/index.html
+++ b/example-generic/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Generic Static Site Example</title>
+    <link rel="stylesheet" href="assets/styles.css">
+  </head>
+  <body>
+    <main class="page">
+      <section class="card">
+        <p class="eyebrow">Static Site Tools</p>
+        <h1>Generic static site example</h1>
+        <p>
+          This example is plain HTML and CSS. The generic installer packages
+          these files as-is without running Astro, Hugo, Jekyll, or another
+          framework-specific build step.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/install.py
+++ b/install.py
@@ -9,7 +9,7 @@ def make_parser():
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("platform", choices=["astro", "hugo", "jekyll"])
+    parser.add_argument("platform", choices=["astro", "generic", "hugo", "jekyll"])
 
     # Mutually exclusive group for version selection
     version_group = parser.add_mutually_exclusive_group()

--- a/test_install.py
+++ b/test_install.py
@@ -36,7 +36,7 @@ class TestMakeParser(unittest.TestCase):
     def test_platform_choices(self):
         """Test that platform argument accepts valid choices."""
         # Test valid platforms
-        for platform in ["astro", "hugo", "jekyll"]:
+        for platform in ["astro", "generic", "hugo", "jekyll"]:
             args = self.parser.parse_args([platform])
             self.assertEqual(args.platform, platform)
 
@@ -559,6 +559,33 @@ class TestInstall(unittest.TestCase):
 
         update_args, _ = mock_update.call_args_list[0]
         self.assertEqual(update_args[2], "develop")
+
+    @patch("install.update_reusable_workflow_references")
+    @patch("install.edit_source_directory")
+    @patch("install.download_file")
+    def test_install_generic_platform(self, mock_download, mock_edit, mock_update):
+        """Test install function with the generic platform."""
+        install("generic", "branch", "main", ".github/workflows", "static")
+
+        expected_url = (
+            "https://raw.githubusercontent.com/omsf/static-site-tools/"
+            "refs/heads/main/.github/workflows/example-generic-build-pr.yaml"
+        )
+        expected_dest = pathlib.Path(".github/workflows") / "build-pr.yaml"
+
+        first_call_args, _ = mock_download.call_args_list[0]
+        self.assertEqual(first_call_args[0], expected_url)
+        self.assertEqual(first_call_args[1], expected_dest)
+
+        edit_args, _ = mock_edit.call_args_list[0]
+        self.assertEqual(edit_args[0], expected_dest)
+        self.assertEqual(edit_args[1], "generic")
+        self.assertEqual(edit_args[2], "static")
+
+        update_args, _ = mock_update.call_args_list[0]
+        self.assertEqual(update_args[0], expected_dest)
+        self.assertEqual(update_args[1], "omsf/static-site-tools")
+        self.assertEqual(update_args[2], "main")
 
 
 class TestIntegration(unittest.TestCase):

--- a/test_install.sh
+++ b/test_install.sh
@@ -14,7 +14,7 @@ repo=$(gh api repos/:owner/:repo --jq '.name')
 
 mkdir -p test_install_dir
 
-platforms=("hugo" "astro" "jekyll")
+platforms=("hugo" "astro" "jekyll" "generic")
 fnames=("build-pr.yaml" "build-push.yaml" "prod-cloudflare.yaml" "stage-cloudflare.yaml" "cleanup-cloudflare.yaml")
 
 exitcode=0

--- a/test_install.sh
+++ b/test_install.sh
@@ -46,9 +46,18 @@ PY
             exitcode=1
         fi
 
-        if ! grep -q "@$version" "$file2"; then
-            echo "    Missing pinned reference @$version in $file2"
-            exitcode=1
+        repo_uses_pattern="uses:[[:space:]]+($owner/$repo|omsf/static-site-tools)/[^[:space:]@]+@"
+
+        if grep -Eq "$repo_uses_pattern" "$temp_expected"; then
+            if ! grep -Eq "$repo_uses_pattern" "$file2"; then
+                echo "    Missing expected reusable workflow/action reference in $file2"
+                exitcode=1
+            elif ! grep -q "@$version" "$file2"; then
+                echo "    Missing pinned reference @$version in $file2"
+                exitcode=1
+            fi
+        else
+            echo "    No reusable workflow/action references to pin in $file2."
         fi
 
         rm -f "$temp_expected"


### PR DESCRIPTION
Adds support for static sites that don't conform to our prescribed tools. My goal is to use this for things like [benchmarking-analysis](https://github.com/omsf-eco-infra/benchmarking-analysis), which uses a non-standard WASM build-step.